### PR TITLE
Wrap around treesitter grammar to be resistant against tree_sitter crates mismatches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,18 +10,14 @@ edition = "2018"
 license = "MIT"
 
 build = "bindings/rust/build.rs"
-include = [
-  "bindings/rust/*",
-  "grammar.js",
-  "queries/*",
-  "src/*",
-]
+include = ["bindings/rust/*", "grammar.js", "queries/*", "src/*"]
 
 [lib]
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = ">= 0.19, < 0.21"
+tree-sitter = "0.25.10"
+tree-sitter-language = "0.1.5"
 
 [build-dependencies]
 cc = "1.0"

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -10,27 +10,27 @@
 //!     }
 //! "#;
 //! let mut parser = tree_sitter::Parser::new();
-//! parser.set_language(tree_sitter_dot::language()).expect("Error loading dot grammar");
+//! let language = tree_sitter_dot::LANGUAGE;
+//! parser.set_language(&language.into()).expect("Error loading dot grammar");
 //! let tree = parser.parse(code, None).unwrap();
 //! ```
 //!
-//! [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
-//! [language func]: fn.language.html
 //! [Parser]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Parser.html
 //! [tree-sitter]: https://tree-sitter.github.io/
 
-use tree_sitter::Language;
+/// Use LanguageFn instead of Language struct direct so we do not have issues
+/// between different versions
+use tree_sitter_language::LanguageFn;
 
 extern "C" {
-    fn tree_sitter_dot() -> Language;
+    fn tree_sitter_dot() -> *const ();
 }
 
-/// Get the tree-sitter [Language][] for this grammar.
+/// Get the tree-sitter grammar for dot.
 ///
 /// [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
-pub fn language() -> Language {
-    unsafe { tree_sitter_dot() }
-}
+/// [LanguageFn]: https://docs.rs/tree-sitter-language/*/tree_sitter_language/struct.LanguageFn.html
+pub const LANGUAGE: LanguageFn = unsafe { LanguageFn::from_raw(tree_sitter_dot) };
 
 /// The content of the [`node-types.json`][] file for this grammar.
 ///
@@ -46,7 +46,7 @@ mod tests {
     fn test_can_load_grammar() {
         let mut parser = tree_sitter::Parser::new();
         parser
-            .set_language(super::language())
+            .set_language(&super::LANGUAGE.into())
             .expect("Error loading dot language");
     }
 }


### PR DESCRIPTION
Hi, I was trying to add dot support for https://mergiraf.org/ and noticed that your grammar is not wrapped around. 

I hope you don't mind my patch!

BR,
Lucas