### PR TITLE
Move tree-sitter crate to dev-dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,9 @@ include = ["bindings/rust/*", "grammar.js", "queries/*", "src/*"]
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "0.25.10"
 tree-sitter-language = "0.1.5"
 
 [build-dependencies]
 cc = "1.0"
+[dev-dependencies]
+tree-sitter = "0.25.10"


### PR DESCRIPTION
Depending on the tree-sitter directly is not right, and cause issues when integrating this grammar into other tools, such as 
https://codeberg.org/mergiraf/mergiraf.

